### PR TITLE
Add @enonic-types/lib-router types #193

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -2,6 +2,10 @@ name: Gradle Build
 
 on: [ push, workflow_dispatch ]
 
+permissions:
+  id-token: write  # Required for npm OIDC / trusted publishing
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,6 +18,7 @@ jobs:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
           codecovToken: ${{ secrets.CODECOV_TOKEN }}
+          npmPublish: true
           releaseBranch: |
             3.x
             4.x

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,3 +41,18 @@ tasks.check {
 artifacts {
     add("archives", tasks.jar)
 }
+
+// Assemble the @enonic-types/lib-router npm package (published on release by the CI npmPublish step).
+val assembleTypes = tasks.register<Copy>("assembleTypes") {
+    from("types")
+    into(layout.buildDirectory.dir("types"))
+    filesMatching("package.json") {
+        filter { line ->
+            line.replace(Regex("\"version\":\\s*\"[^\"]*\""), "\"version\": \"${project.version}\"")
+        }
+    }
+}
+
+tasks.jar {
+    dependsOn(assembleTypes)
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,96 @@
+import type { Request, Response } from "@enonic-types/core";
+
+/**
+ * A request received by a route handler.
+ *
+ * The router populates `pathParams` from the matched route's placeholders
+ * (e.g. `/persons/{id}` → `req.pathParams.id`) before invoking the handler.
+ */
+export type RouterRequest = Request & {
+    pathParams: Record<string, string | undefined>;
+};
+
+/**
+ * Handler invoked when a route matches.
+ */
+export type RouteHandler = (req: RouterRequest) => Response;
+
+/**
+ * Filter invoked in the dispatch chain before route matching.
+ * Call `next(req)` to continue, or return a response to short-circuit.
+ */
+export type Filter = (
+    req: Request,
+    next: (req: Request) => Response
+) => Response;
+
+/**
+ * Path pattern to match. Either a single pattern or an array of patterns
+ * that share the same handler.
+ */
+export type Pattern = string | string[];
+
+export interface Router {
+    /**
+     * Adds a route to this router.
+     *
+     * @param method Method to match. `'*'` for any method.
+     * @param pattern Path pattern (or patterns) to match.
+     * @param handler Handler to execute on match.
+     */
+    route(method: string, pattern: Pattern, handler: RouteHandler): void;
+
+    /**
+     * Adds a route that matches the GET method.
+     */
+    get(pattern: Pattern, handler: RouteHandler): void;
+
+    /**
+     * Adds a route that matches the POST method.
+     */
+    post(pattern: Pattern, handler: RouteHandler): void;
+
+    /**
+     * Adds a route that matches the DELETE method.
+     */
+    delete(pattern: Pattern, handler: RouteHandler): void;
+
+    /**
+     * Adds a route that matches the PUT method.
+     */
+    put(pattern: Pattern, handler: RouteHandler): void;
+
+    /**
+     * Adds a route that matches the HEAD method.
+     */
+    head(pattern: Pattern, handler: RouteHandler): void;
+
+    /**
+     * Adds a route that matches the PATCH method.
+     */
+    patch(pattern: Pattern, handler: RouteHandler): void;
+
+    /**
+     * Adds a route that matches all methods.
+     */
+    all(pattern: Pattern, handler: RouteHandler): void;
+
+    /**
+     * Adds a filter to this router. Filters run in insertion order before
+     * route matching.
+     */
+    filter(filter: Filter): void;
+
+    /**
+     * Dispatch the request through the filter chain and matched route.
+     * Returns a 404 response when no route matches.
+     */
+    dispatch(req: Request): Response;
+}
+
+/**
+ * Creates a new router instance.
+ */
+declare function newRouter(): Router;
+
+export default newRouter;

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@enonic-types/lib-router",
+  "version": "0.0.0",
+  "description": "Type definitions for the Enonic XP Router library",
+  "types": "index.d.ts",
+  "files": [
+    "*"
+  ],
+  "keywords": [
+    "enonic",
+    "enonic-xp",
+    "lib-router",
+    "router",
+    "types",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/enonic/lib-router#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enonic/lib-router.git"
+  },
+  "bugs": {
+    "url": "https://github.com/enonic/lib-router/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@enonic-types/core": "^8.0.0"
+  }
+}


### PR DESCRIPTION
Publishes a TypeScript types package for **lib-router** so consumers get typed access to `/lib/router` from the library itself, instead of relying on the community-maintained `@item-enonic-types/lib-router` (XP-7-pinned; causes `Request`/`Response` collisions under XP 8) or scattered `@ts-ignore` / `@ts-expect-error` copies in apps like app-fotoware, app-explorer, doc-lib-static, lib-static, etc.

Mirrors the scaffolding introduced for `@enonic-types/lib-mustache` (enonic/lib-mustache#66).

## Changes

- `types/index.d.ts` — ambient types for the default-callable factory (`import Router from '/lib/router'; Router()`), route helpers (`get`/`post`/`put`/`delete`/`head`/`patch`/`all`), `route(method, pattern, handler)`, `filter`, `dispatch`, and the `RouterRequest` shape (`Request & { pathParams: Record<string, string | undefined> }`). Signatures verified against `src/main/resources/lib/router.js` and the underlying `com.enonic.xp.lib.router.Router` bean. `Pattern` is `string | string[]` because `router.route` does `[].concat(pattern || '')` over its input.
- `types/package.json` — `@enonic-types/lib-router`, version substituted at build from `project.version`, `dependencies: { "@enonic-types/core": "^8.0.0" }`, `publishConfig.access: public`.
- `build.gradle.kts` — `assembleTypes` `Copy` task (Kotlin DSL equivalent of the Groovy task in lib-mustache); wired via `jar.dependsOn(assembleTypes)`.
- `.github/workflows/enonic-gradle.yml` — `npmPublish: true` on `build-and-publish` + top-level `permissions: { id-token: write, contents: write }` for OIDC trusted publishing.

## Notes on the .d.ts shape

Unlike lib-mustache — which uses `declare module "/lib/mustache" { export function render... }` — lib-router's runtime export is a default-callable function (`module.exports = function () { return new Router(); }`), and TypeScript does not permit `export default` inside module augmentation form. So this .d.ts follows the same shape as the existing `@enonic-types/lib-*` packages that have a default export (e.g. `@enonic-types/lib-static`): a top-level module file (`import type ... from "@enonic-types/core"`; typed exports; `export default newRouter`). Consumers map `"/lib/router"` to `"./node_modules/@enonic-types/lib-router"` via `tsconfig.json` `paths`, matching the existing convention.

## Verified

- `./gradlew build` green.
- `build/types/` contains `index.d.ts` + `package.json` with substituted version (`4.1.0-SNAPSHOT`).
- The `.d.ts` type-checks (`tsc --strict`) against `@enonic-types/core@8.0.0` with a consumer that exercises the full API surface (all route helpers, both `string` and `string[]` patterns, filter, dispatch, `pathParams` access).

## Rollout

The first publish of a brand-new `@enonic-types/lib-router` may need the npm trusted-publisher / package access configured org-side. Depends on enonic/release-tools#71 (publish-only `npmPublish`) — merged.

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)