### PR TITLE
Align docs to lib-cors layout #195

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "4.x"
       - "3.x"
     paths:
       - 'docs/**'

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -2,6 +2,8 @@
 
 image::https://img.shields.io/badge/xp-8.+-blue.svg[role="right"]
 
+NOTE: Versions 4.x target XP 8+.
+
 This library implements a simple HTTP router. It should be used from an application's `webapp.js` controller.
 
 To start using this library, put the following into your `build.gradle` file:
@@ -101,9 +103,6 @@ router.route('GET', '/persons/?', function(req) {
   ...
 });
 ----
-
-NOTE: Before version 3.0.0 trailing slashes were always ignored.
-Starting from version 3.0.0 trailing slash should be explicitly specified in pattern.
 
 Specify multiple patterns for the same handler:
 

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,6 +1,6 @@
 {
   "versions": [
-    { "label": "stable", "checkout": "3.x", "latest": true },
-    { "label": "next", "checkout": "master" }
+    { "label": "stable", "checkout": "4.x", "latest": true },
+    { "label": "3.x", "checkout": "3.x" }
   ]
 }


### PR DESCRIPTION
Aligns lib-router's docs to the same structure as `enonic/lib-cors`, and removes "what was added when" clutter from the current XP 8 docs.

## Changes

- `docs/index.adoc`: added `NOTE: Versions 4.x target XP 8+.` near the top. Removed the version-history NOTE about pre-3.0.0 trailing-slash behavior; the current example (`/persons/?`) already shows how to opt into trailing slashes.
- `docs/versions.json`: now lists `4.x` (label `stable`, `latest: true`) and `3.x` — matching lib-cors's shape. The prior `next → master` entry is dropped; `master` is a rolling development branch, not a published version.
- `.github/workflows/enonic-docgen.yml`: `on.push.branches` now includes `master`, `4.x`, `3.x` — master + every branch listed in `versions.json`.

## Kept deliberately

- `== Compatibility` section — still current, useful info ("XP 8.0.0+").
- `image::.../xp-8.+-blue.svg` badge — target-version indicator, not "since X.Y" clutter.
- `4.0.0` version reference in the `build.gradle` include snippet — an install example, not history.
- The XP 7 branch (`3.x`) docs are left untouched; a cherry-pick to the `4.x` stable branch will follow.

Closes #195