### PR TITLE
Align docs to lib-cors layout #195

### DIFF
--- a/.github/workflows/enonic-docgen.yml
+++ b/.github/workflows/enonic-docgen.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - "4.x"
+      - "3.x"
     paths:
       - 'docs/**'
   workflow_dispatch:

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,6 +1,8 @@
 = Router Library
 
-image::https://img.shields.io/badge/xp-7.+-blue.svg[role="right"]
+image::https://img.shields.io/badge/xp-8.+-blue.svg[role="right"]
+
+NOTE: Versions 4.x target XP 8+.
 
 This library implements a simple HTTP router. It should be used from an application's `webapp.js` controller.
 
@@ -9,7 +11,7 @@ To start using this library, put the following into your `build.gradle` file:
 [source,groovy]
 ----
 dependencies {
-  include 'com.enonic.lib:lib-router:3.1.0'
+  include 'com.enonic.lib:lib-router:4.0.0'
 }
 ----
 
@@ -93,7 +95,6 @@ router.all('/persons', function(req) {
 });
 ----
 
-image::https://img.shields.io/badge/3.+-blue.svg[role="left"]
 Match URL with and without trailing slash:
 
 [source,js]
@@ -103,10 +104,6 @@ router.route('GET', '/persons/?', function(req) {
 });
 ----
 
-NOTE: Before version 3.0.0 trailing slashes were always ignored.
-Starting from version 3.0.0 trailing slash should be explicitly specified in pattern.
-
-image::https://img.shields.io/badge/3.+-blue.svg[role="left"]
 Specify multiple patterns for the same handler:
 
 [source,js]
@@ -303,4 +300,4 @@ exports.all = function(req) {
 
 == Compatibility
 
-This library requires Enonic XP release *7.0.0* or higher.
+This library requires Enonic XP release *8.0.0* or higher.

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -1,0 +1,6 @@
+{
+  "versions": [
+    { "label": "stable", "checkout": "4.x", "latest": true },
+    { "label": "3.x", "checkout": "3.x" }
+  ]
+}


### PR DESCRIPTION
Applies the same docs cleanup PR #196 makes on `master`, to the `4.x` stable branch. This branch's docs were still referencing XP 7 / lib-router 3.1.0 even though `4.x` is the XP 8 line.

## Changes

- `docs/index.adoc`:
  - Added `NOTE: Versions 4.x target XP 8+.` near the top.
  - Bumped the target-version badge from `xp-7.+` to `xp-8.+`.
  - Bumped the install snippet's version from `3.1.0` to `4.0.0`.
  - Bumped the `== Compatibility` line from XP 7 to XP 8.
  - Dropped two legacy `badge/3.+` "since 3.x" image markers.
  - Dropped the pre-3.0.0 trailing-slash version-history NOTE; the current example (`/persons/?`) already shows how to opt into trailing slashes.
- `docs/versions.json` (new file): lists `4.x` (label `stable`, `latest: true`) and `3.x` — matching the shape used on `master` and on lib-cors.
- `.github/workflows/enonic-docgen.yml`: `on.push.branches` now includes `master`, `4.x`, `3.x` — master + every branch listed in `versions.json`.

The `3.x` (XP 7) branch is deliberately left untouched.

Refs #195